### PR TITLE
docs: replace temporary Discord invite URL with permanent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Open grants will be awarded to individuals and teams building tooling and applic
 ## How to apply
 
 1. Submit an [issue](https://github.com/livepeer/Grant-Program/issues/new/choose). Product-based proposals must include specs in the submission. Include mockups, technical milestones, and time estimates. When in doubt breakdown milestones further. 
-2. Application will be reviewed by Livepeer Grants, which meets bi-weekly to discuss all on-going and proposed grants. (If you are interested in joining Livepeer Grants, ping @hansy, @shann, @adam, or @ericxtang in the #community-grants [Discord](https://discord.gg/cmpB7sH) channel.) Applications will receive a decision for funding within 2-4 weeks of applying.
+2. Application will be reviewed by Livepeer Grants, which meets bi-weekly to discuss all on-going and proposed grants. (If you are interested in joining Livepeer Grants, ping @hansy, @shann, @adam, or @ericxtang in the #community-grants [Discord](https://discord.gg/livepeer) channel.) Applications will receive a decision for funding within 2-4 weeks of applying.
 3. Approved grants will receive 20% of the total grant value upfront, followed by graduated payments in the form of milestone completions. Payment is made in LPT (on Arbitrum) based on the USD value of the milestone. The price of LPT used to make the payments is determined using a rolling 30-day average from the time the transaction is queued.
 4. Feedback will occur throughout the grant process 
 
@@ -75,4 +75,3 @@ _Note: This repo is migrated from the [previous repo](https://github.com/Livepee
 Interested in partnering with the Livepeer? We’d love to hear how we can join forces to drive awareness, understanding, and adoption of crypto technologies further into mainstream and digital-native audiences.
 
 For any sponsorship requests for your conference, hackathon, event, etc, please fill out the [following application](https://github.com/livepeer/Grant-Program/issues/new?assignees=shann7&labels=&projects=&template=sponsorship.yml&title=%5BSponsorship%5D%3A+%3CEvent+Name+Here%3E).
-


### PR DESCRIPTION
This pull request updates the Discord invite URL from a temporary (expiring)
link to a fixed (permanent) one to ensure long-term accessibility.
