### PR TITLE
Update the Discord link to the current invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Open grants will be awarded to individuals and teams building tooling and applic
 ## How to apply
 
 1. Submit an [issue](https://github.com/livepeer/Grant-Program/issues/new/choose). Product-based proposals must include specs in the submission. Include mockups, technical milestones, and time estimates. When in doubt breakdown milestones further. 
-2. Application will be reviewed by Livepeer Grants, which meets bi-weekly to discuss all on-going and proposed grants. (If you are interested in joining Livepeer Grants, ping @hansy, @shann, @adam, or @ericxtang in the #community-grants [Discord](https://discord.gg/livepeer) channel.) Applications will receive a decision for funding within 2-4 weeks of applying.
+2. Application will be reviewed by Livepeer Grants, which meets bi-weekly to discuss all on-going and proposed grants. (If you are interested in joining Livepeer Grants, ping @hansy, @shann, @adam, or @ericxtang in the #community-grants [Discord](https://discord.gg/55SZFEEH5y) channel.) Applications will receive a decision for funding within 2-4 weeks of applying.
 3. Approved grants will receive 20% of the total grant value upfront, followed by graduated payments in the form of milestone completions. Payment is made in LPT (on Arbitrum) based on the USD value of the milestone. The price of LPT used to make the payments is determined using a rolling 30-day average from the time the transaction is queued.
 4. Feedback will occur throughout the grant process 
 


### PR DESCRIPTION
## What changed

The `discord.gg/livepeer` vanity URL no longer resolves to the Livepeer Discord server. The `#community-grants` link in the "How to apply" section now points at the current, non-expiring invite `https://discord.gg/55SZFEEH5y`.

Docs only; the repository's deprecation notice is untouched.

## Notes for reviewers

- The invite code `55SZFEEH5y` matches the one adopted in livepeer/website#94 and livepeer/docs#995.
- This supersedes #298, which set the now-dead vanity URL.